### PR TITLE
fix: ensure table colors are visible

### DIFF
--- a/citelang/main/colors.py
+++ b/citelang/main/colors.py
@@ -24,6 +24,14 @@ palettes = {
 }
 
 
+# Generally safe colors for light or black backgrounds in the 16 color palette.
+# See also https://robotmoon.com/256-colors/
+termColors = [
+    1, 2, 3, 4, 5, 6, 
+    9, 10, 11, 12, 13, 14,
+]
+
+
 def get_random_color():
     return "#" + "".join([random.choice("ABCDEF0123456789") for i in range(6)])
 
@@ -32,7 +40,7 @@ def get_rich_color():
     """
     Return a random color
     """
-    return "color(" + str(random.choice(range(255))) + ")"
+    return "color(" + str(random.choice(termColors)) + ")"
 
 
 def get_rich_colors(N):


### PR DESCRIPTION
A boring but fairly safe way of ensuring the table colors are visible on most light/dark terminal backgrounds.

Pick only from the non white/black basic colors in the minimal 16 color palette.

Might be a bit too boring, but it works.

Fixes #25