### PR TITLE
adding support to use pypi resolver to get dependency list from file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on GitHub.
 
 ## [0.0.x](https://github.com/vsoch/citelang/tree/main) (0.0.x)
+ - using pip to parse requirements files, falling back to static (0.0.25)
  - bug fixes for package managers, adding cache to indicate skip package (0.0.24)
  - do not count empty lines, and allow for skipping files by name (0.0.23)
  - custom filters file can better group authors (0.0.22)

--- a/citelang/defaults.py
+++ b/citelang/defaults.py
@@ -29,6 +29,9 @@ default_settings_file = os.path.join(reps["$install_dir"], "settings.yml")
 # Optionally can come from environment
 env_settings_file = os.environ.get("CITELANG_SETTINGS_FILE")
 
+# Don't try using pip
+use_pip = False if os.environ.get("CITELANG_USE_PIP") == "false" else True
+
 # The user settings file can be created to over-ride default
 user_settings_file = os.path.join(citelang_home, "settings.yml")
 

--- a/citelang/main/colors.py
+++ b/citelang/main/colors.py
@@ -27,8 +27,18 @@ palettes = {
 # Generally safe colors for light or black backgrounds in the 16 color palette.
 # See also https://robotmoon.com/256-colors/
 termColors = [
-    1, 2, 3, 4, 5, 6, 
-    9, 10, 11, 12, 13, 14,
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    9,
+    10,
+    11,
+    12,
+    13,
+    14,
 ]
 
 

--- a/citelang/main/package.py
+++ b/citelang/main/package.py
@@ -15,7 +15,6 @@ def get_package(
     data=None,
     use_cache=True,
     manager_kwargs=None,
-    parsed_data=None,
 ):
     """
     Return a package handle for a custom package (defined in citelang) or libraries.io
@@ -30,7 +29,6 @@ def get_package(
             manager=manager,
             version=version,
             data=data,
-            parsed_data=parsed_data,
             use_cache=use_cache,
             manager_kwargs=manager_kwargs,
         )
@@ -40,7 +38,6 @@ def get_package(
         name=name,
         manager=manager,
         version=version,
-        parsed_data=parsed_data,
         data=data,
         use_cache=use_cache,
     )
@@ -53,7 +50,6 @@ class PackageBase:
         name,
         version=None,
         data=None,
-        parsed_data=None,
         use_cache=True,
         manager_kwargs=None,
     ):
@@ -65,7 +61,6 @@ class PackageBase:
         self.parse(name)
         self.data = data or {}
         self.latest = None
-        self.parsed_data = parsed_data or {}
         self.use_cache = use_cache
         self.cache = cache.cache
         self.manager_kwargs = manager_kwargs or {}

--- a/citelang/main/package.py
+++ b/citelang/main/package.py
@@ -9,7 +9,13 @@ from citelang.logger import logger
 
 
 def get_package(
-    manager, name, version=None, data=None, use_cache=True, manager_kwargs=None
+    manager,
+    name,
+    version=None,
+    data=None,
+    use_cache=True,
+    manager_kwargs=None,
+    parsed_data=None,
 ):
     """
     Return a package handle for a custom package (defined in citelang) or libraries.io
@@ -24,6 +30,7 @@ def get_package(
             manager=manager,
             version=version,
             data=data,
+            parsed_data=parsed_data,
             use_cache=use_cache,
             manager_kwargs=manager_kwargs,
         )
@@ -33,6 +40,7 @@ def get_package(
         name=name,
         manager=manager,
         version=version,
+        parsed_data=parsed_data,
         data=data,
         use_cache=use_cache,
     )
@@ -45,6 +53,7 @@ class PackageBase:
         name,
         version=None,
         data=None,
+        parsed_data=None,
         use_cache=True,
         manager_kwargs=None,
     ):
@@ -56,6 +65,7 @@ class PackageBase:
         self.parse(name)
         self.data = data or {}
         self.latest = None
+        self.parsed_data = parsed_data or {}
         self.use_cache = use_cache
         self.cache = cache.cache
         self.manager_kwargs = manager_kwargs or {}
@@ -104,6 +114,21 @@ class CustomPackage(PackageBase):
     A wrapper for a custom package (provided by citelang)
     """
 
+    def __init__(
+        self,
+        manager,
+        name,
+        version=None,
+        data=None,
+        use_cache=True,
+        manager_kwargs=None,
+    ):
+        super().__init__(manager, name, version, data, use_cache, manager_kwargs)
+        if not self.underlying_manager:
+            self.underlying_manager = packages.managers[self.manager](
+                **self.manager_kwargs
+            )
+
     @property
     def homepage(self):
         url = self.data.get("homepage") or self.data.get("package", {}).get("homepage")
@@ -115,10 +140,6 @@ class CustomPackage(PackageBase):
         """
         Retrieve custom package dependencies
         """
-        if not self.underlying_manager:
-            self.underlying_manager = packages.managers[self.manager](
-                **self.manager_kwargs
-            )
         manager = self.underlying_manager
 
         # Use manager cache first
@@ -173,10 +194,6 @@ class CustomPackage(PackageBase):
         """
         Get info for a custom package
         """
-        if not self.underlying_manager:
-            self.underlying_manager = packages.managers[self.manager](
-                **self.manager_kwargs
-            )
         manager = self.underlying_manager
 
         # Use manager cache first

--- a/citelang/main/packages/base.py
+++ b/citelang/main/packages/base.py
@@ -70,9 +70,9 @@ class PackagesFromFile(PackageManager):
 
     filesystem_manager = True
 
-    def __init__(self, package_name=None, content=None):
+    def __init__(self, package_name=None, content=None, filename=None):
         """
-        An R package manager parses packages from a DESCRIPTION
+        An base filesystem package manager parses packages from a file
         """
         self.version = None
         self.package_name = package_name
@@ -80,6 +80,7 @@ class PackagesFromFile(PackageManager):
         if package_name:
             self.set_name(package_name)
         self.data = {}
+        self.filename = filename
         if content:
             self.parse(content)
 
@@ -126,9 +127,14 @@ class PackagesFromFile(PackageManager):
             except:
                 pass
 
-        # If we get down here and no package, mark empty
+        # If we get down here and no package, mark empty (unless it isn't a package we know)
         if not pkg:
-            self.cache.mark_empty(f"package/{self.underlying_manager}/{package_name}")
+            try:
+                self.cache.mark_empty(
+                    f"package/{self.underlying_manager}/{package_name}"
+                )
+            except:
+                pass
         return pkg
 
     def get_repo(self):
@@ -155,7 +161,7 @@ class PackagesFromFile(PackageManager):
         """
         return self.data.get("package")
 
-    def parse(self, content):
+    def parse(self, content, **kwargs):
         """
         Parse the self.content
         """

--- a/citelang/main/packages/go_mod.py
+++ b/citelang/main/packages/go_mod.py
@@ -18,7 +18,7 @@ class GoModuleManager(PackagesFromFile):
     color = "#007d9c"
     default_versions = None
 
-    def parse(self, content):
+    def parse(self, content, **kwargs):
         """
         Parse the self.content (the Gemfile)
         """

--- a/citelang/main/packages/npm_packages.py
+++ b/citelang/main/packages/npm_packages.py
@@ -41,6 +41,8 @@ class NPMPackageManager(PackagesFromFile):
             # Always get rid of @ - doesn't seem to get hits
             package_name = package_name.replace("@", "", 1)
             pkg = self.get_package(package_name, version)
+            if not package_name:
+                continue
 
             # If we don't have a package, try using start of name
             if not pkg:

--- a/citelang/main/packages/npm_packages.py
+++ b/citelang/main/packages/npm_packages.py
@@ -22,7 +22,7 @@ class NPMPackageManager(PackagesFromFile):
     color = "#d54d25"
     default_versions = None
 
-    def parse(self, content):
+    def parse(self, content, **kwargs):
         """
         Parse the self.content (the packages.json)
         """

--- a/citelang/main/packages/pip_wrapper.py
+++ b/citelang/main/packages/pip_wrapper.py
@@ -1,0 +1,176 @@
+__author__ = "Vanessa Sochat"
+__copyright__ = "Copyright 2022, Vanessa Sochat"
+__license__ = "MPL 2.0"
+
+from pip._internal.commands.install import (
+    InstallCommand,
+    reject_location_related_install_options,
+)
+from pip._internal.cli.cmdoptions import make_target_python
+from pip._internal.cli.main_parser import create_main_parser
+from pip._internal.req.req_tracker import get_requirement_tracker
+from pip._internal.utils.temp_dir import TempDirectory
+from pip._internal.cli import cmdoptions
+from pip._internal.cache import WheelCache
+
+from citelang.logger import logger
+import citelang.utils as utils
+import re
+import os
+
+from .base import PackagesFromFile
+
+
+class PackageLister(InstallCommand):
+    """
+    A wrapper to the pypi install command that simply resolves dependencies
+    and saves the listing. A requirements.txt file will work outside of context,
+    however a setup.py typically needs external dependencies (and if it does
+    not work, will fall back to the static parser).
+    """
+
+    def run(self, options, args):
+        cmdoptions.check_dist_restriction(options, check_target=True)
+        options.use_user_site = True
+        session = self.get_default_session(options)
+        target_python = make_target_python(options)
+        finder = self._build_package_finder(
+            options=options,
+            session=session,
+            target_python=target_python,
+            ignore_requires_python=options.ignore_requires_python,
+        )
+        try:
+            reqs = self.get_requirements(args, options, finder, session)
+            self._citelang_success = True
+
+            # requirements.txt will be parsed already
+            if "." not in args:
+                self._citelang_reqs = reqs
+                return 0
+
+            # If we are installing a setup.py, we need to parse
+            for req in reqs:
+                req.permit_editable_wheels = True
+
+            req_tracker = self.enter_context(get_requirement_tracker())
+            wheel_cache = WheelCache(options.cache_dir, options.format_control)
+            reject_location_related_install_options(reqs, options.install_options)
+            directory = TempDirectory(
+                delete=True,
+                kind="install",
+                globally_managed=True,
+            )
+            preparer = self.make_requirement_preparer(
+                temp_build_dir=directory,
+                options=options,
+                req_tracker=req_tracker,
+                session=session,
+                finder=finder,
+                use_user_site=options.use_user_site,
+                verbosity=self.verbosity,
+            )
+            resolver = self.make_resolver(
+                preparer=preparer,
+                finder=finder,
+                options=options,
+                wheel_cache=wheel_cache,
+                use_user_site=options.use_user_site,
+                ignore_installed=options.ignore_installed,
+                ignore_requires_python=options.ignore_requires_python,
+                force_reinstall=options.force_reinstall,
+                upgrade_strategy="to-satisfy-only",
+                use_pep517=options.use_pep517,
+            )
+            self.trace_basic_info(finder)
+            self._citelang_reqs = resolver.resolve(
+                reqs, check_supported_wheels=False
+            ).all_requirements
+
+        except:
+            self._citelang_success = False
+            logger.warning(
+                "Issue using pip to resolve dependencies, will fall back to static parser."
+            )
+            self._citelang_reqs = []
+
+        # Always return success to main
+        return 0
+
+
+class PipManager(PackagesFromFile):
+    def parse_python_deps(self, lines):
+        """
+        Shared function for deriving a list of python dependencies from lines
+        """
+        parser = create_main_parser()
+        args = []
+        if self.filename.endswith("requirements.txt"):
+            # Generate args based on a faux command
+            args = ["install", "-r", "requirements.txt"]
+        if self.filename.endswith("setup.py"):
+            args = ["install", "."]
+
+        general_options, args_else = parser.parse_args(args)
+        cmd_name = args_else[0]
+        cmd_args = args[:]
+        cmd_args.remove(cmd_name)
+
+        # Instead of parsing the content we instead parse the filename
+        dirname = os.path.dirname(self.filename)
+        lister = PackageLister("citelang", "listing of Citelang packages")
+
+        with utils.workdir(dirname):
+            lister.main(cmd_args)
+
+        # If we don't have deps, fall back to static parser
+        if not lister._citelang_success:
+            from .python_base import PythonManager as FallbackParser
+
+            FallbackParser.name = self.name
+            mgr = FallbackParser(package_name=self.package_name, filename=self.filename)
+            return mgr.parse_python_deps(lines=lines, filename=self.filename)
+
+        deps = []
+        for dep in lister._citelang_reqs:
+            package_name = dep.name
+            version = None
+
+            # We can only use package names that could be on pip
+            if not package_name:
+                continue
+            if dep.specifier:
+                version = str(dep.specifier)
+            if version and re.search("(==|~=|<=|>=|<|>|!=)", version):
+                version = re.sub("(==|~=|<=|>=|<|>|!=)", "", version).strip()
+
+            # First add requirements (names and pypi manager) to deps
+            pkg = self.get_package(package_name, version)
+            if not pkg:
+                pkg = self.get_package(package_name)
+                if not pkg:
+                    logger.warning("Issue getting package %s, skipping" % package_name)
+                    continue
+
+            # Ensure we have version, fallback to latest
+            if not version:
+                version = pkg.data["latest_release_number"]
+
+            # Require saving to cache here - many expensive calls
+            cache_name = f"package/pypi/{package_name}/{version}"
+            self.cache.set(cache_name, pkg)
+
+            # use latest release version. This will be wrong for an old
+            # dependency, but it's not worth it to make a ton of extra API calls
+            dep = {
+                "name": package_name,
+                "project_name": package_name,
+                "number": version,
+                "published_at": pkg.data["latest_stable_release_published_at"],
+                "researched_at": None,
+                "spdx_expression": "NOASSERTION",
+                "original_license": pkg.data["licenses"],
+                "repository_sources": ["Pypi"],
+            }
+            deps.append(dep)
+        return deps

--- a/citelang/main/packages/pip_wrapper.py
+++ b/citelang/main/packages/pip_wrapper.py
@@ -87,10 +87,11 @@ class PackageLister(InstallCommand):
                 reqs, check_supported_wheels=False
             ).all_requirements
 
-        except:
+        except Exception as err:
             self._citelang_success = False
             logger.warning(
-                "Issue using pip to resolve dependencies, will fall back to static parser."
+                "Issue using pip to resolve dependencies: %s, will fall back to static parser."
+                % err
             )
             self._citelang_reqs = []
 

--- a/citelang/main/packages/pypi_requirements.py
+++ b/citelang/main/packages/pypi_requirements.py
@@ -3,75 +3,22 @@ __copyright__ = "Copyright 2022, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 from citelang.logger import logger
+import citelang.defaults as defaults
 import re
 
-from .base import PackagesFromFile
+try:
+    # The python manager that uses pip is more reliable
+    if defaults.use_pip:
+        from .pip_wrapper import PipManager as PythonManager
+    else:
+        from .python_base import PythonManager
+except:
+    # vs. static parsing, not perfect but fairly good!
+    from .python_base import PythonManager
 
-
-class PythonManager(PackagesFromFile):
-    def parse_python_deps(self, lines):
-        """
-        Shared function for deriving a list of python dependencies from lines
-        """
-        # Dependencies we parse as pypi packages
-        # This should also update the cache and make it easier to retrieve later
-        deps = []
-        for line in lines:
-
-            line = line.split("#", 1)[0]
-
-            # skip comments
-            if line.strip().startswith("#"):
-                continue
-
-            # We can't easily add github pypi references
-            if not line or "git@" in line:
-                continue
-
-            version = None
-            package_name = line.strip()
-            if re.search("(==|~=|<=|>=|<|>|!=)", package_name):
-                package_name, _, version = re.split(
-                    "(==|~=|<=|>=|<|>|!=)", package_name
-                )
-                version = version.strip()
-            package_name = package_name.strip()
-
-            # We cannot parse a dep without a name
-            if not package_name:
-                continue
-
-            # Remove variants
-            package_name = re.sub("\[.+\]", "", package_name)
-
-            # First add requirements (names and pypi manager) to deps
-            pkg = self.get_package(package_name, version)
-            if not pkg:
-                logger.warning("Issue getting package %s, skipping" % package_name)
-                continue
-
-            # Ensure we have version, fallback to latest
-            if not version:
-                version = pkg.data["latest_release_number"]
-
-            # Require saving to cache here - many expensive calls
-            cache_name = f"package/pypi/{package_name}/{version}"
-            self.cache.set(cache_name, pkg)
-
-            # use latest release version. This will be wrong for an old
-            # dependency, but it's not worth it to make a ton of extra API calls
-            dep = {
-                "name": package_name,
-                "project_name": package_name,
-                "number": version,
-                "published_at": pkg.data["latest_stable_release_published_at"],
-                "researched_at": None,
-                "spdx_expression": "NOASSERTION",
-                "original_license": pkg.data["licenses"],
-                "repository_sources": ["Pypi"],
-            }
-            deps.append(dep)
-        return deps
+    logger.warning(
+        "pip not installed on system, parsing will be done statically (less reliable)"
+    )
 
 
 class RequirementsManager(PythonManager):
@@ -88,7 +35,7 @@ class RequirementsManager(PythonManager):
     default_language = "Python"
     default_versions = None
 
-    def parse(self, content):
+    def parse(self, content, **kwargs):
         """
         Parse the self.content (the requirements.txt file)
         """
@@ -115,7 +62,7 @@ class SetupManager(PythonManager):
     default_language = "Python"
     default_versions = None
 
-    def parse(self, content):
+    def parse(self, content, **kwargs):
         """
         Parse the self.content (the requirements.txt file)
         """
@@ -189,8 +136,6 @@ class SetupManager(PythonManager):
 
         # Remove any variants (e.g., [all])
         cleaned = [re.sub("\[.+\]", "", x) for x in cleaned]
-
-        print(cleaned)
         deps = self.parse_python_deps(cleaned)
         repo["dependencies"] = deps
         self.data["package"] = repo

--- a/citelang/main/packages/python_base.py
+++ b/citelang/main/packages/python_base.py
@@ -1,0 +1,84 @@
+__author__ = "Vanessa Sochat"
+__copyright__ = "Copyright 2022, Vanessa Sochat"
+__license__ = "MPL 2.0"
+
+from citelang.logger import logger
+import re
+
+from .base import PackagesFromFile
+
+
+class PythonManager(PackagesFromFile):
+    underlying_manager = "pypi"
+    project_count = None
+    homepage = "pypi.org/"
+    color = "#006dad"
+    default_language = "Python"
+    default_versions = None
+
+    def parse_python_deps(self, lines, **kwargs):
+        """
+        Shared function for deriving a list of python dependencies from lines
+        """
+        # Dependencies we parse as pypi packages
+        # This should also update the cache and make it easier to retrieve later
+        deps = []
+        for line in lines:
+
+            # Skip local installs with -e
+            if "-e" in line:
+                continue
+            line = line.split("#", 1)[0]
+
+            # skip comments
+            if line.strip().startswith("#"):
+                continue
+
+            # We can't easily add github pypi references
+            if not line or "git@" in line:
+                continue
+
+            version = None
+            package_name = line.strip()
+            if re.search("(==|~=|<=|>=|<|>|!=)", package_name):
+                package_name, _, version = re.split(
+                    "(==|~=|<=|>=|<|>|!=)", package_name
+                )
+                version = version.strip()
+            package_name = package_name.strip()
+
+            # We cannot parse a dep without a name
+            if not package_name:
+                continue
+
+            # Remove variants
+            package_name = re.sub("\[.+\]", "", package_name)
+
+            # First add requirements (names and pypi manager) to deps
+            pkg = self.get_package(package_name, version)
+            if not pkg:
+                logger.warning("Issue getting package %s, skipping" % package_name)
+                continue
+
+            # Ensure we have version, fallback to latest
+            if not version:
+                version = pkg.data["latest_release_number"]
+
+            # Require saving to cache here - many expensive calls
+            cache_name = f"package/pypi/{package_name}/{version}"
+            self.cache.set(cache_name, pkg)
+
+            # use latest release version. This will be wrong for an old
+            # dependency, but it's not worth it to make a ton of extra API calls
+            dep = {
+                "name": package_name,
+                "project_name": package_name,
+                "number": version,
+                "published_at": pkg.data["latest_stable_release_published_at"],
+                "researched_at": None,
+                "spdx_expression": "NOASSERTION",
+                "original_license": pkg.data["licenses"],
+                "repository_sources": ["Pypi"],
+            }
+            deps.append(dep)
+        return deps

--- a/citelang/main/packages/ruby_gem.py
+++ b/citelang/main/packages/ruby_gem.py
@@ -19,7 +19,7 @@ class GemfileManager(PackagesFromFile):
     color = "#e9573f"
     default_versions = None
 
-    def parse(self, content):
+    def parse(self, content, **kwargs):
         """
         Parse the self.content (the Gemfile)
         """

--- a/citelang/main/parser.py
+++ b/citelang/main/parser.py
@@ -304,7 +304,10 @@ class RequirementsParser(FileNameParser):
                 if manager not in roots:
                     roots[manager] = {}
                 for libname, libmeta in libs.items():
+                    if not libname:
+                        continue
                     if libname not in roots[manager]:
+                        libmeta["credit"] = libmeta["credit"] * splitby
                         roots[manager][libname] = libmeta
                     else:
                         if libmeta["url"] and not roots[manager][libname]["url"]:

--- a/citelang/main/parser.py
+++ b/citelang/main/parser.py
@@ -271,7 +271,7 @@ class RequirementsParser(FileNameParser):
         """
         Generate a badge for a requirements file.
         """
-        self.gen(filename=filename, name=name, *args, **kwargs)
+        self.gen(filename=filename or self.filename, name=name, *args, **kwargs)
         root = list(self.roots.values())[0]
         if template == "treemap":
             return results.Treemap(root)
@@ -297,7 +297,11 @@ class RequirementsParser(FileNameParser):
         pkg = None
 
         if basename in packages.filesystem_manager_names:
-            manager_kwargs = {"content": self.content, "package_name": name}
+            manager_kwargs = {
+                "content": self.content,
+                "package_name": name,
+                "filename": filename,
+            }
 
             # Custom set the name of the manager
             pkg = package.get_package(

--- a/citelang/version.py
+++ b/citelang/version.py
@@ -2,7 +2,7 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright 2022, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
-__version__ = "0.0.24"
+__version__ = "0.0.25"
 AUTHOR = "Vanessa Sochat"
 EMAIL = "vsoch@users.noreply.github.com"
 NAME = "citelang"

--- a/docs/getting_started/user-guide.rst
+++ b/docs/getting_started/user-guide.rst
@@ -595,7 +595,7 @@ Requirements Files
 ^^^^^^^^^^^^^^^^^^
 
 If you instead provide a name and filename to render, you can generate the same
-kind of rendering for a custom package (possibly not on pypi or other package managers):s
+kind of rendering for a custom package (possibly not on pypi or other package managers):
 
 .. code-block:: console
 
@@ -607,7 +607,14 @@ Here is a setup.py, harder to parse but we try!
 
    $ citelang gen python-lib setup.py --outfile mylib.md
 
-And a Gemfile:
+
+For each of the python file types, by default we use pip to parse (and get a more accurate result than static). However if there is some issue, it will fall back to the static parser. You can also disable using pipe entirely by doing:
+
+.. code-block:: console
+
+    export CITELANG_USE_PIP=false
+
+As we move on to other languages, here is an example of parsing a Gemfile:
 
 .. code-block:: console
 
@@ -931,9 +938,8 @@ Adding an additional step to commit a file and push to main might look like:
         git commit -m "Automated push with new software-credit $(date '+%Y-%m-%d')" || exit 0
         git push origin main || exit 0
 
-You could also open a pull request if you want to review first! Note that we have more planned
-for this action, including actions for the render and badge types, along with a development
-variant that can parse a requirements.txt or similar. Stay tuned!
+
+You could also open a pull request if you want to review first!
 
 ******
 Python

--- a/docs/getting_started/user-guide.rst
+++ b/docs/getting_started/user-guide.rst
@@ -670,6 +670,33 @@ two requirements.txt files in a repository, and combining the results:
 
     print(table.render())
 
+Loading Data
+^^^^^^^^^^^^
+
+If you save your client data to file (e.g., to data.json for some repository)
+you can later load it into a parser to combine results.
+
+.. code-block:: python
+
+    # Let's say we have a list of data.json files, each with a repository and dependencies
+    roots = global_cli.load_datafiles(data_files)
+
+    # Let's tweak the round by value to our liking...
+    global_cli.round_by = 100
+    
+    # And render providing the custom data!
+    global_cli.render(data=roots)
+    
+    # You can also do the same, but scope to a type of requirement file
+    data = global_cli.load_datafiles(data_files, includes=["setup.py", "requirements.txt", "pypi"])
+    data = global_cli.load_datafiles(data_files, includes=["cran", "DESCRIPTION"])
+    data = global_cli.load_datafiles(data_files, includes=["package.json", "npm"])
+    data = global_cli.load_datafiles(data_files, includes=["go.mod", "go"])
+
+
+And then you could run a custom render for each to generate the requirements table, but scoped
+to a language.
+
 
 Contrib
 =======


### PR DESCRIPTION
As suggested by @alecbcs, this approach can be slightly more accurate! It works very well for requirements.txt files that can exist outside of the context ofa repo, however for setup.py it is ideally run in context of the repository, as that context is needed for success. Either way, if an attempt is not successful we fall back to the static parser. I am running it now across the entire rsepedia Python set and will do a final review / merge when everything looks good

It does appear that the pip libraries needed are private so we can likely expect change and breaking, but in this case it will automatically fall back to static parsing, and hopefully someone will open an issue so we know when to update (if I don't find it).

Signed-off-by: vsoch <vsoch@users.noreply.github.com>