### PR TITLE
contrib: use specific git log range. Avoid --all.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on GitHub.
 
 ## [0.0.x](https://github.com/vsoch/citelang/tree/main) (0.0.x)
+ - contrib does not count commits from other REFs, now uses git log without `--all` (0.0.30)
  - Default contrib does a deep search, with option to add `--shallow` (0.0.29)
  - Adding basic support for parsing CMakeLists.txt (0.0.28)
  - JoSS paper and sort package names in listing (0.0.27)

--- a/citelang/version.py
+++ b/citelang/version.py
@@ -2,7 +2,7 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright 2022, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
-__version__ = "0.0.29"
+__version__ = "0.0.30"
 AUTHOR = "Vanessa Sochat"
 EMAIL = "vsoch@users.noreply.github.com"
 NAME = "citelang"


### PR DESCRIPTION
Because `git log --all` effectively adds REFS in `refs/` to the `git log` call it will produce output listing commits from all the REFS in our local repo.

Citelang was getting a list of `--all` commits, and then filtering between start and end points. Because of this, it could pick up commits that are not really in the section of history we are interested in - but come from a fork, or usptream with shared history earlier on.

Call `git log` with a specific commit range so that it directly provides the correct list of commits we need to consider.

As a bonus, you can now use other refs like branches or deltas as `--start` and `--end` points.

Fixes #35