### PR TITLE
fix: prevent exiting the loop when one package `dep_credit` is too small

### DIFF
--- a/citelang/client/__init__.py
+++ b/citelang/client/__init__.py
@@ -196,10 +196,11 @@ def get_parser():
 
     for command in [graph, credit, badge, render, gen]:
         command.add_argument(
-            "--max-depth", help="maximum depth to parse tree (default is unset)"
+            "--max-depth", type=int, help="maximum depth to parse tree (default is unset)"
         )
         command.add_argument(
             "--max-deps",
+            type=int,
             help="maximum number of dependencies to include (default is unset)",
         )
         command.add_argument(


### PR DESCRIPTION
Currently when processing a dependency list file, if a package with a `dep_credit` below `min_credit` has a higher precedence over the other packages in the list, the code logic would exit the loop and prevent looking into the dependencies of the rest of the packages in the list.  

This PR changes the logic, instead of exiting the loop, the code will jump to look into dependencies of the rest of the packages in `next_nodes`. It also fixes type errors when parsing `--max-depth` and `--max-deps` arguments by adding type converters for the arguments in the command-line.  

